### PR TITLE
feat: 添加Rect参数中lineStyle默认值

### DIFF
--- a/plugin/series/Rect.js
+++ b/plugin/series/Rect.js
@@ -11,7 +11,7 @@ module.exports = {
                 // color = '',
                 bgColor = '',
                 radius = 0,
-                lineStyle
+                lineStyle = {}
                 // blur = 0
             } = config
 


### PR DESCRIPTION
画矩形的时候，边框不是必须的，但是如果不传lineStyle会报错，添加默认值可以简化用法
```javascript
import { Rect } from 'wx-canvas-2d'

canvas.draw({
    series: [
        {
            type: Rect,
            x: 40,
            y: 40,
            width: 520,
            height: 520,
            bgColor: '#0ff',
            lineStyle: {},  // 不需要边框，但必须传参
        }
    ]
})
``` 